### PR TITLE
thumb64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.0.2 - 2018-07-26
+### Added
+- thumb64 function/filter
+
 ## 1.0.1 - 2018-07-23
 ### Added
 - Version Modification

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This Twig extension requires that you pass an instance of a Craft [`Asset`](http
 
 ## Usage
 
-### As a Twig Function
+### Base64-encode asset
+
+#### As a Twig Function
 
 ###### With default options
 
@@ -26,6 +28,25 @@ This Twig extension requires that you pass an instance of a Craft [`Asset`](http
 
 This will return the base64-encoded string in a [data URI scheme](http://en.wikipedia.org/wiki/Data_URI_scheme). The default value is `false`.
 
-### As a Twig Filter
+#### As a Twig Filter
 
 	{{ asset|image64 }}
+    
+### Base64-encode thumbnail
+
+#### As a Twig Function
+
+###### With default options
+
+	{{ thumb64(asset) }}
+
+###### With `inline` set to `true` and width to 200px
+
+	{{ thumb64(asset, 200, true) }}
+
+Second parameter is thumbnail width, default to 100px;
+Setting third parameter to `true` will return the base64-encoded string in a [data URI scheme](http://en.wikipedia.org/wiki/Data_URI_scheme). The default value is `false`.
+
+#### As a Twig Filter
+
+	{{ asset|thumb64 }}    

--- a/src/twigextensions/Crafttwigimagebase64TwigExtension.php
+++ b/src/twigextensions/Crafttwigimagebase64TwigExtension.php
@@ -52,6 +52,7 @@ class Crafttwigimagebase64TwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFilter('image64', [$this, 'image64']),
+            new \Twig_SimpleFilter('thumb64', [$this, 'thumb64']),
         ];
     }
 
@@ -66,6 +67,7 @@ class Crafttwigimagebase64TwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFunction('image64', [$this, 'image64']),
+            new \Twig_SimpleFunction('thumb64', [$this, 'thumb64']),
         ];
     }
 
@@ -89,9 +91,32 @@ class Crafttwigimagebase64TwigExtension extends \Twig_Extension
             // Die quietly.
             return false;
         }
+        
+        $binary = file_get_contents(Craft::$app->getAssets()->getThumbPath($asset, 100, 100));
 
         // Get the file.
-        $binary = file_get_contents($asset->getCopyOfFile());
+        //$binary = file_get_contents($asset->getCopyOfFile());
+
+        // Return the string.
+        return $inline ? sprintf('data:image/%s;base64,%s', $asset->getExtension(), base64_encode($binary)) : base64_encode($binary);
+    }
+    
+    public function thumb64($asset, $width=100, $inline = false)
+    {
+        // Make sure it is an asset object
+        if (!$asset instanceof Asset) {
+          // Die quietly.
+            return false;
+        }
+
+        // Make sure the mime type is an image.
+        if (0 !== strpos($asset->getMimeType(), 'image/')) {
+            // Die quietly.
+            return false;
+        }
+        
+        // Get the file.
+        $binary = file_get_contents(Craft::$app->getAssets()->getThumbPath($asset, $width));
 
         // Return the string.
         return $inline ? sprintf('data:image/%s;base64,%s', $asset->getExtension(), base64_encode($binary)) : base64_encode($binary);


### PR DESCRIPTION
I have added `thumb64` function/filter which generates base64 code for asset thumbnail. This can be especially useful for SVG image preloaders.