### PR TITLE
feat: Craft CMS 4.x compatibility work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 !.vscode/extensions.json
 config.codekit3
 prepros-6.config
+composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.0.3 - 2019-04-24
+## Unrelease
+
+### Updated
+- feat: Craft CMS 4.x compatibility work
+
+## 1.0.4 - 2019-04-24
 ### Updated
 - new icon
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "kisonay/craft-twig-imagebase64",
   "description": "Base64 encode images within twig templates.",
   "type": "craft-plugin",
-  "version": "1.0.4",
   "keywords": [
     "craft",
     "cms",
@@ -20,7 +19,11 @@
     "homepage": "https://github.com/kisonay/"
   }],
   "require": {
-    "craftcms/cms": "^3.0.0"
+    "php": "^8.0",
+    "craftcms/cms": "^4.0"
+  },
+  "require-dev": {
+    "craftcms/rector": "dev-main"
   },
   "autoload": {
     "psr-4": {
@@ -34,5 +37,13 @@
     "hasCpSection": false,
     "changelogUrl": "https://raw.githubusercontent.com/kisonay/craft-twig-imagebase64/master/CHANGELOG.md",
     "class": "kisonay\\crafttwigimagebase64\\Crafttwigimagebase64"
-  }
+  },
+  "config": {
+    "allow-plugins": {
+      "yiisoft/yii2-composer": true,
+      "craftcms/plugin-installer": true
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/src/Crafttwigimagebase64.php
+++ b/src/Crafttwigimagebase64.php
@@ -55,7 +55,7 @@ class Crafttwigimagebase64 extends Plugin
      *
      * @var string
      */
-    public $schemaVersion = '1.0.0';
+    public string $schemaVersion = '1.0.0';
 
     // Public Methods
     // =========================================================================

--- a/src/twigextensions/Crafttwigimagebase64TwigExtension.php
+++ b/src/twigextensions/Crafttwigimagebase64TwigExtension.php
@@ -26,7 +26,7 @@ use Craft;
  * @package   Crafttwigimagebase64
  * @since     1.0.0
  */
-class Crafttwigimagebase64TwigExtension extends \Twig_Extension
+class Crafttwigimagebase64TwigExtension extends \Twig\Extension\AbstractExtension
 {
     // Public Methods
     // =========================================================================
@@ -51,8 +51,8 @@ class Crafttwigimagebase64TwigExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('image64', [$this, 'image64']),
-            new \Twig_SimpleFilter('thumb64', [$this, 'thumb64']),
+            new \Twig\TwigFilter('image64', [$this, 'image64']),
+            new \Twig\TwigFilter('thumb64', [$this, 'thumb64']),
         ];
     }
 
@@ -66,8 +66,8 @@ class Crafttwigimagebase64TwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('image64', [$this, 'image64']),
-            new \Twig_SimpleFunction('thumb64', [$this, 'thumb64']),
+            new \Twig\TwigFunction('image64', [$this, 'image64']),
+            new \Twig\TwigFunction('thumb64', [$this, 'thumb64']),
         ];
     }
 


### PR DESCRIPTION
Seems making the plugin Craft CMS 4 is trivial (applied the instructions from the docs, ran the Rector rules). However, not sure this should be merged into `master`, as currently Craft CMS 3 is also still supported. So some sort of dual branch setup is needed?