### PR TITLE
Fixed error 'Calling unknown method getThumbPath' in Craft 4

### DIFF
--- a/src/helpers/Thumbs.php
+++ b/src/helpers/Thumbs.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace kisonay\crafttwigimagebase64\helpers;
+
+use craft\elements\Asset;
+use craft\models\ImageTransform;
+
+class Thumbs
+{
+    public static function getUrl(Asset $asset, $width = null, $height = null): string
+    {
+        $transform = new ImageTransform([
+            'width' => $width,
+            'height' => $height,
+            'mode' => 'crop',
+        ]);
+
+        return $asset->getUrl($transform);
+    }
+}

--- a/src/twigextensions/Crafttwigimagebase64TwigExtension.php
+++ b/src/twigextensions/Crafttwigimagebase64TwigExtension.php
@@ -11,6 +11,7 @@
 namespace kisonay\crafttwigimagebase64\twigextensions;
 
 use kisonay\crafttwigimagebase64\Crafttwigimagebase64;
+use kisonay\crafttwigimagebase64\helpers\Thumbs as ThumbsHelper;
 use craft\elements\Asset;
 
 use Craft;
@@ -98,7 +99,7 @@ class Crafttwigimagebase64TwigExtension extends \Twig\Extension\AbstractExtensio
         // Return the string.
         return $inline ? sprintf('data:image/%s;base64,%s', $asset->getExtension(), base64_encode($binary)) : base64_encode($binary);
     }
-    
+
     public function thumb64($asset, $width=100, $inline = false)
     {
         // Make sure it is an asset object
@@ -114,7 +115,7 @@ class Crafttwigimagebase64TwigExtension extends \Twig\Extension\AbstractExtensio
         }
 
         // Get the file.
-        $binary = file_get_contents(Craft::$app->getAssets()->getThumbPath($asset, $width));
+        $binary = file_get_contents(ThumbsHelper::getUrl($asset, $width));
 
         // Return the string.
         return $inline ? sprintf('data:image/%s;base64,%s', $asset->getExtension(), base64_encode($binary)) : base64_encode($binary);


### PR DESCRIPTION
When using the `thumb64` Twig method error is thrown: Calling unknown method: craft\services\Assets::getThumbPath()

Backtraced to this line: https://github.com/kisonay/craft-twig-imagebase64/blob/093c30eb5fd5f1261b7fe6f5e98263b56e866ba4/src/twigextensions/Crafttwigimagebase64TwigExtension.php#L117

The `getThumbPath` function was [removed in Craft CMS 4](https://github.com/craftcms/cms/blob/72122c099e702529756d2f0a3bc5a582d632cd90/CHANGELOG.md?plain=1#L2666), so in this pull request, it is replaced by a new helper method to handle the transform.